### PR TITLE
Remove polyChkTable from bg collision check

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -627,7 +627,6 @@ s32 BgCheck_SphVsFirstDynaPoly(CollisionContext* colCtx, u16 xpFlags, CollisionP
                                Vec3f* center, f32 radius, Actor* actor, u16 bciFlags);
 void CollisionHeader_GetVirtual(void* colHeader, CollisionHeader** dest);
 void func_800418D0(CollisionContext* colCtx, PlayState* play);
-void BgCheck_ResetPolyCheckTbl(SSNodeList* nodeList, s32 numPolys);
 u32 SurfaceType_GetBgCamIndex(CollisionContext* colCtx, CollisionPoly* poly, s32 bgId);
 u16 BgCheck_GetBgCamSettingImpl(CollisionContext* colCtx, u32 bgCamIndex, s32 bgId);
 u16 BgCheck_GetBgCamSetting(CollisionContext* colCtx, CollisionPoly* poly, s32 bgId);

--- a/include/z64bgcheck.h
+++ b/include/z64bgcheck.h
@@ -120,8 +120,6 @@ typedef struct {
     /* 0x00 */ u16 max;          // original name: short_slist_node_size
     /* 0x02 */ u16 count;        // original name: short_slist_node_last_index
     /* 0x04 */ SSNode* tbl;      // original name: short_slist_node_tbl
-    /* 0x08 */ u8* polyCheckTbl; // points to an array of bytes, one per static poly. Zero initialized when starting a
-                                 // bg check, and set to 1 if that poly has already been tested.
 } SSNodeList;
 
 typedef struct {

--- a/src/code/z_bgcheck.c
+++ b/src/code/z_bgcheck.c
@@ -901,7 +901,7 @@ s32 BgCheck_CheckStaticCeiling(StaticLookup* lookup, u16 xpFlags, CollisionConte
 }
 
 /**
- * Tests if line `posA` to `posB` intersects with a static poly in list `ssList`. Uses polyCheckTbl
+ * Tests if line `posA` to `posB` intersects with a static poly in list `ssList`.
  * returns true if such a poly exists, else false
  * `outPoly` returns the pointer of the poly intersected
  * `posB` and `outPos` returns the point of intersection with `outPoly`
@@ -911,7 +911,6 @@ s32 BgCheck_CheckLineAgainstSSList(SSList* ssList, CollisionContext* colCtx, u16
                                    Vec3f* posB, Vec3f* outPos, CollisionPoly** outPoly, f32* outDistSq, f32 chkDist,
                                    s32 bccFlags) {
     SSNode* curNode;
-    u8* checkedPoly;
     Vec3f polyIntersect;
     CollisionPoly* polyList;
     CollisionPoly* curPoly;
@@ -929,9 +928,8 @@ s32 BgCheck_CheckLineAgainstSSList(SSList* ssList, CollisionContext* colCtx, u16
     curNode = &colCtx->polyNodes.tbl[ssList->head];
     while (true) {
         polyId = curNode->polyId;
-        checkedPoly = &colCtx->polyNodes.polyCheckTbl[polyId];
 
-        if (*checkedPoly == true || COLPOLY_VIA_FLAG_TEST(polyList[polyId].flags_vIA, xpFlags1) ||
+        if (COLPOLY_VIA_FLAG_TEST(polyList[polyId].flags_vIA, xpFlags1) ||
             !(xpFlags2 == 0 || COLPOLY_VIA_FLAG_TEST(polyList[polyId].flags_vIA, xpFlags2))) {
 
             if (curNode->next == SS_NULL) {
@@ -941,7 +939,6 @@ s32 BgCheck_CheckLineAgainstSSList(SSList* ssList, CollisionContext* colCtx, u16
                 continue;
             }
         }
-        *checkedPoly = true;
         curPoly = &polyList[polyId];
         minY = CollisionPoly_GetMinY(curPoly, colCtx->colHeader->vtxList);
         if (posA->y < minY && posB->y < minY) {
@@ -968,7 +965,7 @@ s32 BgCheck_CheckLineAgainstSSList(SSList* ssList, CollisionContext* colCtx, u16
 }
 
 /**
- * Tests if line `posA` to `posB` intersects with a static poly in `lookup`. Uses polyCheckTbl
+ * Tests if line `posA` to `posB` intersects with a static poly in `lookup`.
  * returns true if such a poly exists, else false
  * `outPoly` returns the pointer of the poly intersected
  * `posB` and `outPos` returns the point of intersection with `outPoly`
@@ -2155,7 +2152,6 @@ s32 BgCheck_CheckLineImpl(CollisionContext* colCtx, u16 xpFlags1, u16 xpFlags2, 
         }
     }
 
-    BgCheck_ResetPolyCheckTbl(&colCtx->polyNodes, colCtx->colHeader->numPolygons);
     BgCheck_GetStaticLookupIndicesFromPos(colCtx, posA, (Vec3i*)&subdivMin);
     BgCheck_GetStaticLookupIndicesFromPos(colCtx, &posBTemp, (Vec3i*)&subdivMax);
     *posResult = *posB;
@@ -2405,7 +2401,6 @@ void SSNodeList_Initialize(SSNodeList* this) {
     this->max = 0;
     this->count = 0;
     this->tbl = NULL;
-    this->polyCheckTbl = NULL;
 }
 
 /**
@@ -2419,10 +2414,6 @@ void SSNodeList_Alloc(PlayState* play, SSNodeList* this, s32 tblMax, s32 numPoly
     this->tbl = THA_AllocEndAlign(&play->state.tha, tblMax * sizeof(SSNode), -2);
 
     ASSERT(this->tbl != NULL, "this->short_slist_node_tbl != NULL", "../z_bgcheck.c", 5975);
-
-    this->polyCheckTbl = GameState_Alloc(&play->state, numPolys, "../z_bgcheck.c", 5979);
-
-    ASSERT(this->polyCheckTbl != NULL, "this->polygon_check != NULL", "../z_bgcheck.c", 5981);
 }
 
 /**
@@ -3798,17 +3789,6 @@ void func_800418D0(CollisionContext* colCtx, PlayState* play) {
             Actor_SetObjectDependency(play, dyna->bgActors[i].actor);
             CollisionHeader_SegmentedToVirtual(dyna->bgActors[i].colHeader);
         }
-    }
-}
-
-/**
- * Reset SSNodeList polyCheckTbl
- */
-void BgCheck_ResetPolyCheckTbl(SSNodeList* nodeList, s32 numPolys) {
-    u8* t;
-
-    for (t = nodeList->polyCheckTbl; t < nodeList->polyCheckTbl + numPolys; t++) {
-        *t = 0;
     }
 }
 


### PR DESCRIPTION
So this was a MASSIVE performance improvement in my project. I'm talking having 2 enemies in a room at 10 fps, to 7 enemies at 20 fps, in a large dungeon scene that was nearing the collision poly limit.

I suspect this was one of the original devs ideas of an optimization; don't check polys you've already checked for that update cycle, makes sense. but the data structure they used (array) just destroys any gains you would have gotten. It's significantly faster to just re-check the polys than it is to go through and clear the table after you're done checking, because that table gets large for dungeon scenes. And this is called through BgCheck_CheckLineImpl which is like the most foundational collision function in the whole BgCheck system, so it is called tons of times every frame. I am not kidding when I say I doubled my framerate and doubled the # of enemies loaded to maintain a consistent 20fps, just by ripping out this system.