### PR TITLE
Add build date

### DIFF
--- a/src/boot/build.c
+++ b/src/boot/build.c
@@ -1,3 +1,7 @@
-const char gBuildTeam[] = "zelda@srd022j";
-const char gBuildDate[] = "03-02-21 00:16:31";
+const char gBuildTeam[] = "HackerOOT";
+const char gBuildDate[] = __TIME__;
+#ifndef NDEBUG
 const char gBuildMakeOption[] = "";
+#else
+const char gBuildMakeOption[] = "-DNDEBUG";
+#endif


### PR DESCRIPTION
Adds the build date using `__TIME__` and adds build options, This is normally displayed in-game through the N64 logo screen.