### PR TITLE
Fixed ``EntranceInfo`` having the wrong name for ``sceneId``

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -1360,7 +1360,7 @@ typedef struct {
      & (ENTRANCE_INFO_START_TRANS_TYPE_MASK >> ENTRANCE_INFO_START_TRANS_TYPE_SHIFT))
 
 typedef struct {
-    /* 0x00 */ u8  scene;
+    /* 0x00 */ u8  sceneId;
     /* 0x01 */ u8  spawn;
     /* 0x02 */ u16 field;
 } EntranceInfo; // size = 0x4


### PR DESCRIPTION
I changed the struct to make it like it is in the decomp project, let me know if you want the other name (so keeping ``scene`` in the struct and change every usage in code)