### PR TITLE
Dynamically Allocate the Get Item Segment

### DIFF
--- a/include/z64player.h
+++ b/include/z64player.h
@@ -383,6 +383,8 @@ typedef struct {
     /* 0x10 */ Vec3f base;
 } WeaponInfo; // size = 0x1C
 
+#define PLAYER_GI_SEG_MIN 0x2880 // max size of a place title card file
+
 #define PLAYER_STATE1_0 (1 << 0)
 #define PLAYER_STATE1_SWINGING_BOTTLE (1 << 1)
 #define PLAYER_STATE1_2 (1 << 2)
@@ -491,6 +493,7 @@ typedef struct Player {
     /* 0x0194 */ OSMesgQueue giObjectLoadQueue;
     /* 0x01AC */ OSMesg     giObjectLoadMsg;
     /* 0x01B0 */ void*      giObjectSegment; // also used for title card textures
+                 u32        giObjectSegmentMaxSz;
     /* 0x01B4 */ SkelAnime  skelAnime;
     /* 0x01F8 */ Vec3s      jointTable[PLAYER_LIMB_BUF_COUNT];
     /* 0x0288 */ Vec3s      morphTable[PLAYER_LIMB_BUF_COUNT];

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9288,6 +9288,20 @@ static void (*D_80854738[])(PlayState* play, Player* this) = {
 
 static Vec3f D_80854778 = { 0.0f, 50.0f, 0.0f };
 
+u32 Player_GetLargestGI(void) {
+    u32 maxObjSize = 0, curObjSize = 0;
+    for (s32 i = 0; true; i++) {
+        u16 objId = sGetItemTable[i].objectId;
+        if (objId == OBJECT_INVALID) {
+            return maxObjSize;
+        }
+        curObjSize = gObjectTable[objId].vromEnd - gObjectTable[objId].vromStart;
+        if (curObjSize > maxObjSize) {
+            maxObjSize = curObjSize;
+        }
+    }
+}
+
 void Player_Init(Actor* thisx, PlayState* play2) {
     Player* this = (Player*)thisx;
     PlayState* play = play2;
@@ -9318,7 +9332,8 @@ void Player_Init(Actor* thisx, PlayState* play2) {
     Player_SetEquipmentData(play, this);
     this->prevBoots = this->currentBoots;
     Player_InitCommon(this, play, gPlayerSkelHeaders[((void)0, gSaveContext.linkAge)]);
-    this->giObjectSegment = (void*)(((uintptr_t)ZeldaArena_MallocDebug(0x3008, "../z_player.c", 17175) + 8) & ~0xF);
+    this->giObjectSegment = (void*)ALIGN16((uintptr_t)ZeldaArena_MallocDebug(Player_GetLargestGI() + 16, __FILE__, __LINE__));
+    *(u32*)0x80700000 = Player_GetLargestGI() + 16;
 
     respawnFlag = gSaveContext.respawnFlag;
 

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9332,8 +9332,14 @@ void Player_Init(Actor* thisx, PlayState* play2) {
     Player_SetEquipmentData(play, this);
     this->prevBoots = this->currentBoots;
     Player_InitCommon(this, play, gPlayerSkelHeaders[((void)0, gSaveContext.linkAge)]);
-    this->giObjectSegment = (void*)ALIGN16((uintptr_t)ZeldaArena_MallocDebug(Player_GetLargestGI() + 16, __FILE__, __LINE__));
-    *(u32*)0x80700000 = Player_GetLargestGI() + 16;
+
+    // Allocate the GI object segment
+    this->giObjectSegmentMaxSz = Player_GetLargestGI() + 16;
+    if (this->giObjectSegmentMaxSz < PLAYER_GI_SEG_MIN) {
+        this->giObjectSegmentMaxSz = PLAYER_GI_SEG_MIN;
+    }
+    this->giObjectSegment =
+        (void*)ALIGN16((uintptr_t)ZeldaArena_MallocDebug(this->giObjectSegmentMaxSz, __FILE__, __LINE__));
 
     respawnFlag = gSaveContext.respawnFlag;
 


### PR DESCRIPTION
This PR adds code in z_player.c to dynamically choose the size of the getItemSegment based on whatever the largest get item object is.