### PR TITLE
Fix for debugState having the wrong condition

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -726,7 +726,7 @@ typedef struct {
     /* 0x01B8 */ OSMesgQueue loadQueue;
     /* 0x01D0 */ OSMesg loadMsg;
     /* 0x01D4 */ u16    state;
-#if (defined ENABLE_INV_EDITOR && defined ENABLE_EVENT_EDITOR)
+#if (defined ENABLE_INV_EDITOR || defined ENABLE_EVENT_EDITOR)
     /* 0x01D6 */ u16    debugState;
 #endif
     /* 0x01D8 */ Vec3f  eye;


### PR DESCRIPTION
This prevented compilation when enabling one of the two options but not both at the same time