### PR TITLE
[Improvement] Added a toggle for automatic GI object allocation

### DIFF
--- a/include/config/config_game.h
+++ b/include/config/config_game.h
@@ -53,4 +53,9 @@
 // Increase the size of small elements (improves readability on N64)
 #define WIDESCREEN_N64_MODE true
 
+/**
+ * Automatic GI Object Allocation
+*/
+// #define ENABLE_AUTO_GI_ALLOC
+
 #endif

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -9693,8 +9693,15 @@ void Player_Init(Actor* thisx, PlayState* play2) {
     Player_SetEquipmentData(play, this);
     this->prevBoots = this->currentBoots;
     Player_InitCommon(this, play, gPlayerSkelHeaders[((void)0, gSaveContext.linkAge)]);
+
+#ifdef ENABLE_AUTO_GI_ALLOC
     this->giObjectSegment =
-        (void*)ALIGN16((uintptr_t)ZeldaArena_MallocDebug(Player_GetGIAllocSize(), __FILE__, __LINE__));
+        (void*)ALIGN16((uintptr_t)ZeldaArena_MallocDebug(Player_GetGIAllocSize(), __BASE_FILE__, __LINE__));
+#else
+    ASSERT(Player_GetGIAllocSize() < 0x3008,
+            "[HackerOoT:ERROR]: GI Object larger than the allocated size.", __BASE_FILE__, __LINE__);
+    this->giObjectSegment = (void*)(((uintptr_t)ZeldaArena_MallocDebug(0x3008, __BASE_FILE__, __LINE__) + 8) & ~0xF);
+#endif
 
     respawnFlag = gSaveContext.respawnFlag;
 


### PR DESCRIPTION
After talking on the decomp discord yesterday I realised forcing the automatic alloc for GI objects isn't great as people might actually want an assert to let them have a better control on the memory, I made an assert before allocating to make sure everything's fine
![image](https://user-images.githubusercontent.com/35189056/217222708-0beaa018-43d2-4442-bfb2-879a7e4340ee.png)
