### PR TITLE
[Fix] Fixed Lens of Truth having two circles in 4:3

### DIFF
--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2338,7 +2338,7 @@ void Actor_DrawLensOverlay(GraphicsContext* gfxCtx) {
                         G_TX_NOLOD);
 
     gDPSetTileSize(POLY_XLU_DISP++, G_TX_RENDERTILE, WIDE_DIV(((SCREEN_WIDTH / 2 - LENS_MASK_WIDTH) << 2), WIDE_GET_RATIO),
-                   (SCREEN_HEIGHT / 2 - LENS_MASK_HEIGHT) << 2, (WIDE_DIV(SCREEN_WIDTH / 2 + LENS_MASK_WIDTH - 1, WIDE_GET_RATIO) + 37) << 2,
+                   (SCREEN_HEIGHT / 2 - LENS_MASK_HEIGHT) << 2, WIDE_INCR(WIDE_DIV(SCREEN_WIDTH / 2 + LENS_MASK_WIDTH - 1, WIDE_GET_RATIO), 37) << 2,
                    (SCREEN_HEIGHT / 2 + LENS_MASK_HEIGHT - 1) << 2);
     gSPTextureRectangle(POLY_XLU_DISP++, 0, 0, SCREEN_WIDTH << 2, SCREEN_HEIGHT << 2, G_TX_RENDERTILE,
                         LENS_MASK_OFFSET_S << 5, LENS_MASK_OFFSET_T << 5,


### PR DESCRIPTION
noticed this yesterday, turns out I just forgot to use a macro