### PR TITLE
Preserve PlayState offsets without ENABLE_FRAMERATE_OPTIONS

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -824,6 +824,8 @@ typedef struct PlayState {
     /* 0x007A8 */ LightContext lightCtx;
 #ifdef ENABLE_FRAMERATE_OPTIONS
     /* 0x007B8 */ FrameAdvanceContext frameAdvCtx;
+#else
+    /* 0x007B8 */ u8 padding[8]; // preserves correct offsets
 #endif
     /* 0x007C0 */ CollisionContext colCtx;
     /* 0x01C24 */ ActorContext actorCtx;


### PR DESCRIPTION
Preserves offset of all members of the PlayState struct when ENABLE_FRAMERATE_OPTIONS is disabled.

For context, i am building a map-editor witch needs to access the members of this struct in RAM.
While i can resolve most variables by name using the z64.map file, member inside struct needs to be hard-coded.
It would help a lot if, at least by default, this struct stays the same.