### PR TITLE
Fixed debug infos not showing on N64 logo

### DIFF
--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -10,7 +10,7 @@
 
 #include "config.h"
 
-#ifdef DEBUG_ROM
+#ifndef RELEASE_ROM
 void ConsoleLogo_PrintBuildInfo(Gfx** gfxp) {
     Gfx* g;
     GfxPrint* printer;
@@ -159,7 +159,7 @@ void ConsoleLogo_Main(GameState* thisx) {
     ConsoleLogo_Update(this);
     ConsoleLogo_Draw(this);
 
-#ifdef DEBUG_ROM
+#ifndef RELEASE_ROM
     ConsoleLogo_PrintBuildInfo(&POLY_OPA_DISP);
 #endif
 


### PR DESCRIPTION
This is really really small so I'm just gonna merge it now