### PR TITLE
add save types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,10 @@ baserom/
 docs/doxygen/
 cache/
 *.elf
+*.ram
+*.sav
 *.sra
+*.srm
 *.z64
 *.n64
 *.v64


### PR DESCRIPTION
decomp assumes your on project 64 even though its literally junk so i added save types for other common emulators.