### PR TITLE
Remove the movie trigger

### DIFF
--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -359,15 +359,6 @@ void Play_Init(GameState* thisx) {
 
     PRINTF("\nSCENE_NO=%d COUNTER=%d\n", ((void)0, gSaveContext.save.entranceIndex), gSaveContext.sceneLayer);
 
-    // When entering Gerudo Valley in the credits, trigger the GC emulator to play the ending movie.
-    // The emulator constantly checks whether PC is 0x81000000, so this works even though it's not a valid address.
-    if ((gEntranceTable[((void)0, gSaveContext.save.entranceIndex)].sceneId == SCENE_GERUDO_VALLEY) &&
-        gSaveContext.sceneLayer == 6) {
-        PRINTF("エンディングはじまるよー\n"); // "The ending starts"
-        ((void (*)(void))0x81000000)();
-        PRINTF("出戻り？\n"); // "Return?"
-    }
-
     Cutscene_HandleEntranceTriggers(this);
     KaleidoScopeCall_Init(this);
     Interface_Init(this);


### PR DESCRIPTION
the credits works properly on Gamecube so this is not necessary at all