### PR TITLE
Use ``s64`` instead of ``s16`` for actor parameters

### DIFF
--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -258,7 +258,7 @@ typedef struct Actor {
     /* 0x003 */ s8 room; // Room number the actor is in. -1 denotes that the actor won't despawn on a room change
     /* 0x004 */ u32 flags; // Flags used for various purposes
     /* 0x008 */ PosRot home; // Initial position/rotation when spawned. Can be used for other purposes
-    /* 0x01C */ s16 params; // Configurable variable set by the actor's spawn data; original name: "args_data"
+    /* 0x01C */ s64 params; // Configurable variable set by the actor's spawn data; original name: "args_data"
     /* 0x01E */ s8 objectSlot; // Object slot (in ObjectContext) corresponding to the actor's object; original name: "bank"
     /* 0x01F */ s8 targetMode; // Controls how far the actor can be targeted from and how far it can stay locked on
     /* 0x020 */ u16 sfx; // SFX ID to play. Sfx plays when value is set, then is cleared the following update cycle

--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -20,7 +20,7 @@ typedef struct {
     /* 0x00 */ s16   id;
     /* 0x02 */ Vec3s pos;
     /* 0x08 */ Vec3s rot;
-    /* 0x0E */ s16   params;
+    /* 0x0E */ s64   params;
 } ActorEntry; // size = 0x10
 
 typedef struct {
@@ -31,7 +31,7 @@ typedef struct {
     /* 0x04 */ s16   id;
     /* 0x06 */ Vec3s pos;
     /* 0x0C */ s16   rotY;
-    /* 0x0E */ s16   params;
+    /* 0x0E */ s64   params;
 } TransitionActorEntry; // size = 0x10
 
 typedef struct {

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -530,7 +530,7 @@ void EnItem00_Collected(EnItem00* this, PlayState* play) {
 void EnItem00_Update(Actor* thisx, PlayState* play) {
     static u32 D_80157D90;
     static s16 D_80157D94[1];
-    s16* params;
+    s64* params;
     Actor* dynaActor;
     s32 getItemId = GI_NONE;
     s16 sp3A = 0;

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -3155,7 +3155,7 @@ void BossVa_BariPostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s*
 }
 
 void BossVa_Draw(Actor* thisx, PlayState* play) {
-    s16* paramsPtr; // This stack slot is almost certainly actually play2, but can't make it match
+    s64* paramsPtr; // This stack slot is almost certainly actually play2, but can't make it match
     BossVa* this = (BossVa*)thisx;
     Vec3f spBC;
     Vec3f spB0 = { 0.0f, 45.0f, 0.0f };

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -147,7 +147,7 @@ void EnSth_SetupShapeColliderUpdate2AndDraw(EnSth* this, PlayState* play) {
 
 void EnSth_SetupAfterObjectLoaded(EnSth* this, PlayState* play) {
     s32 pad;
-    s16* params;
+    s64* params;
 
     EnSth_SetupShapeColliderUpdate2AndDraw(this, play);
     gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.slots[this->requiredObjectSlot].segment);


### PR DESCRIPTION
this was an idea I had after talking with @Reonu about how actor parameters works last month

I kept the pointers because I wanted to make sure it worked fine but imo they're all completely useless, also I used a signed long long instead of an unsigned because it was raising warnings, I compared with current develop/2.1.0 and I have the same number of warnings now so everything should be fine hopefully (ngl I didn't tested this extensively but overall it seems to work properly)

so with this change, if I'm not dumb, instead of having parameters on ``0xABCD``, we can have parameters on ``0xABCDEFGHIJKLMNOP``