### PR TITLE
Remove critical wiggles

### DIFF
--- a/include/config/config_game.h
+++ b/include/config/config_game.h
@@ -66,11 +66,4 @@
 */
 #define ENABLE_VINE_CLIMB_FIX true
 
-/**
- * Enable critical wiggles
- * This is that thing where the player can have a random stick input every 256 frames when you're at critical health
- * See ``Camera_Normal1`` in ``z_camera.c`` for more details.
-*/
-#define ENABLE_CRITICAL_WIGGLES false
-
 #endif

--- a/include/config/config_game.h
+++ b/include/config/config_game.h
@@ -66,4 +66,11 @@
 */
 #define ENABLE_VINE_CLIMB_FIX true
 
+/**
+ * Enable critical wiggles
+ * This is that thing where the player can have a random stick input every 256 frames when you're at critical health
+ * See ``Camera_Normal1`` in ``z_camera.c`` for more details.
+*/
+#define ENABLE_CRITICAL_WIGGLES false
+
 #endif

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -4,8 +4,6 @@
 #include "terminal.h"
 #include "overlays/actors/ovl_En_Horse/z_en_horse.h"
 
-#include "config.h"
-
 // For retail BSS ordering, the block number of D_8015BD7C
 // must be between 88 and 123 inclusive.
 #pragma increment_block_number 30
@@ -1783,14 +1781,6 @@ s32 Camera_Normal1(Camera* camera) {
             camera->inputDir.y = eyeAdjustment.yaw;
             camera->inputDir.z = 0;
         }
-
-#if ENABLE_CRITICAL_WIGGLES
-        // crit wiggle
-        if (gSaveContext.save.info.playerData.health <= 16 && ((camera->play->state.frames % 256) == 0)) {
-            wiggleAdj = Rand_ZeroOne() * 10000.0f;
-            camera->inputDir.y = wiggleAdj + camera->inputDir.y;
-        }
-#endif
     } else {
         rwData->swing.swingUpdateRate = roData->unk_0C;
         rwData->swing.unk_18 = 0;

--- a/src/code/z_camera.c
+++ b/src/code/z_camera.c
@@ -4,6 +4,8 @@
 #include "terminal.h"
 #include "overlays/actors/ovl_En_Horse/z_en_horse.h"
 
+#include "config.h"
+
 // For retail BSS ordering, the block number of D_8015BD7C
 // must be between 88 and 123 inclusive.
 #pragma increment_block_number 30
@@ -1782,11 +1784,13 @@ s32 Camera_Normal1(Camera* camera) {
             camera->inputDir.z = 0;
         }
 
+#if ENABLE_CRITICAL_WIGGLES
         // crit wiggle
         if (gSaveContext.save.info.playerData.health <= 16 && ((camera->play->state.frames % 256) == 0)) {
             wiggleAdj = Rand_ZeroOne() * 10000.0f;
             camera->inputDir.y = wiggleAdj + camera->inputDir.y;
         }
+#endif
     } else {
         rwData->swing.swingUpdateRate = roData->unk_0C;
         rwData->swing.unk_18 = 0;


### PR DESCRIPTION
imo we should remove it entirely but idk, let me know if I should remove the config define

if you don't know what this is about, every 256 frames (if I get the modulo properly lol) the game will add a random value to your horizontal stick input when the health value is under 16 (basically, during critical health, hence the name), this is useless imo, and it bothers lots of people