### PR TITLE
More F3DEX3 no texture load optimizations

### DIFF
--- a/src/code/z_effect_soft_sprite_old_init.c
+++ b/src/code/z_effect_soft_sprite_old_init.c
@@ -50,6 +50,7 @@ void EffectSs_DrawGEffect(PlayState* play, EffectSs* this, void* texture) {
     s32 pad1;
     Mtx* mtx;
     void* objectPtr = play->objectCtx.slots[this->rgObjectSlot].segment;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_effect_soft_sprite_old_init.c", 196);
 
@@ -66,6 +67,7 @@ void EffectSs_DrawGEffect(PlayState* play, EffectSs* this, void* texture) {
     if (mtx != NULL) {
         gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(texture));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, texture);
         Gfx_SetupDL_61Xlu(gfxCtx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rgPrimColorR, this->rgPrimColorG, this->rgPrimColorB,
                         this->rgPrimColorA);

--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -819,6 +819,7 @@ void EnItem00_Draw(Actor* thisx, PlayState* play) {
 void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
     s32 pad;
     s32 texIndex;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_item00.c", 1546);
 
@@ -834,6 +835,7 @@ void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
     gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_item00.c", 1562), G_MTX_MODELVIEW | G_MTX_LOAD);
 
     gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sRupeeTex[texIndex]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, texIndex);
 
     gSPDisplayList(POLY_OPA_DISP++, gRupeeDL);
 
@@ -845,6 +847,7 @@ void EnItem00_DrawRupee(EnItem00* this, PlayState* play) {
  */
 void EnItem00_DrawCollectible(EnItem00* this, PlayState* play) {
     s32 texIndex = this->actor.params - 3;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_item00.c", 1594);
 
@@ -859,6 +862,7 @@ void EnItem00_DrawCollectible(EnItem00* this, PlayState* play) {
     POLY_OPA_DISP = Gfx_SetupDL_66(POLY_OPA_DISP);
 
     gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sItemDropTex[texIndex]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, texIndex);
 
     gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_item00.c", 1607), G_MTX_MODELVIEW | G_MTX_LOAD);
     gSPDisplayList(POLY_OPA_DISP++, gItemDropDL);

--- a/src/code/z_kankyo.c
+++ b/src/code/z_kankyo.c
@@ -1985,6 +1985,7 @@ void Environment_DrawLightning(PlayState* play, s32 unused) {
     s32 pad[2];
     Vec3f unused1 = { 0.0f, 0.0f, 0.0f };
     Vec3f unused2 = { 0.0f, 0.0f, 0.0f };
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_kankyo.c", 3253);
 
@@ -2039,6 +2040,7 @@ void Environment_DrawLightning(PlayState* play, s32 unused) {
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_kankyo.c", 3333),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(lightningTextures[sLightningBolts[i].textureIndex]));
+            IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, sLightningBolts[i].textureIndex);
             Gfx_SetupDL_61Xlu(play->state.gfxCtx);
             gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_NOPUSH | G_MTX_MUL | G_MTX_MODELVIEW);
             gSPDisplayList(POLY_XLU_DISP++, gEffLightningDL);

--- a/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Firewall/z_bg_hidan_firewall.c
@@ -199,12 +199,14 @@ static void* sFireballTexs[] = {
 
 void BgHidanFirewall_Draw(Actor* thisx, PlayState* play) {
     BgHidanFirewall* this = (BgHidanFirewall*)thisx;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_bg_hidan_firewall.c", 448);
 
     POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_20);
 
     gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sFireballTexs[this->unk_150]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->unk_150);
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x01, 255, 255, 0, 150);
     gDPSetEnvColor(POLY_XLU_DISP++, 255, 0, 0, 255);
     gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_bg_hidan_firewall.c", 458),

--- a/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Rsekizou/z_bg_hidan_rsekizou.c
@@ -188,9 +188,11 @@ Gfx* BgHidanRsekizou_DrawFireball(PlayState* play, BgHidanRsekizou* this, s16 fr
     s32 temp;
     f32 fVar6;
     f32 tmpf7;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     temp = (((this->burnFrame + frame) % 8) * 7) * (1.0f / 7.0f);
     gSPSegment(displayList++, 0x09, SEGMENTED_TO_VIRTUAL(sFireballsTexs[temp]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(displayList++, temp);
 
     frame++;
     fVar6 = (frame != 4) ? frame + ((3 - this->bendFrame) * (1.0f / 3.0f)) : frame;

--- a/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sekizou/z_bg_hidan_sekizou.c
@@ -300,9 +300,11 @@ Gfx* func_8088D9F4(PlayState* play, BgHidanSekizou* this, s16 arg2, MtxF* arg3, 
     f32 temp_f0;
     f32 temp_f2;
     f32 phi_f12;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     arg6 = (((arg6 + arg2) % 8) * 7) * (1 / 7.0f);
     gSPSegment(arg7++, 9, SEGMENTED_TO_VIRTUAL(sFireballsTexs[arg6]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(arg7++, arg6);
     arg2++;
     if (arg2 != 4) {
         phi_f12 = arg2 + ((4 - this->unk_170) / 4.0f);

--- a/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
+++ b/src/overlays/actors/ovl_Bg_Hidan_Sima/z_bg_hidan_sima.c
@@ -258,6 +258,7 @@ Gfx* func_8088EB54(PlayState* play, BgHidanSima* this, Gfx* gfx) {
         mtxF.zz += 0.4f;
 
         gSPSegment(gfx++, 0x09, SEGMENTED_TO_VIRTUAL(sFireballsTexs[(this->timer + s3) % 7]));
+        IF_F3DEX3_ALWAYS_DONT_SKIP_TEX(gfx++);
         gSPMatrix(gfx++,
                   Matrix_MtxFToMtx(MATRIX_CHECK_FLOATS(&mtxF, "../z_bg_hidan_sima.c", 611),
                                    GRAPH_ALLOC(play->state.gfxCtx, sizeof(Mtx))),
@@ -267,6 +268,7 @@ Gfx* func_8088EB54(PlayState* play, BgHidanSima* this, Gfx* gfx) {
     mtxF.xw = this->dyna.actor.world.pos.x + (phi_s5 * 25 + 80) * sin;
     mtxF.zw = this->dyna.actor.world.pos.z + (phi_s5 * 25 + 80) * cos;
     gSPSegment(gfx++, 0x09, SEGMENTED_TO_VIRTUAL(sFireballsTexs[(this->timer + s3) % 7]));
+    IF_F3DEX3_ALWAYS_DONT_SKIP_TEX(gfx++);
     gSPMatrix(gfx++,
               Matrix_MtxFToMtx(MATRIX_CHECK_FLOATS(&mtxF, "../z_bg_hidan_sima.c", 624),
                                GRAPH_ALLOC(play->state.gfxCtx, sizeof(Mtx))),

--- a/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
+++ b/src/overlays/actors/ovl_Boss_Fd/z_boss_fd.c
@@ -1529,6 +1529,7 @@ void BossFd_DrawEffects(BossFdEffect* effect, PlayState* play) {
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     s16 i;
     BossFdEffect* firstEffect = effect;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_boss_fd.c", 4023);
 
@@ -1591,6 +1592,7 @@ void BossFd_DrawEffects(BossFdEffect* effect, PlayState* play) {
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gfxCtx, "../z_boss_fd.c", 4104),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(dustTex[effect->timer2]));
+            IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, effect->timer2);
             gSPDisplayList(POLY_XLU_DISP++, gVolvagiaDustModelDL);
         }
     }
@@ -1614,6 +1616,7 @@ void BossFd_DrawEffects(BossFdEffect* effect, PlayState* play) {
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gfxCtx, "../z_boss_fd.c", 4154),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(dustTex[effect->timer2]));
+            IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, effect->timer2);
             gSPDisplayList(POLY_XLU_DISP++, gVolvagiaDustModelDL);
         }
     }

--- a/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
+++ b/src/overlays/actors/ovl_Boss_Ganon/z_boss_ganon.c
@@ -4829,6 +4829,7 @@ void BossGanon_DrawEffects(PlayState* play) {
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     GanondorfEffect* eff = play->specialEffects;
     GanondorfEffect* effFirst = eff;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_boss_ganon.c", 10865);
     Gfx_SetupDL_25Xlu(play->state.gfxCtx);
@@ -4945,6 +4946,7 @@ void BossGanon_DrawEffects(PlayState* play) {
             gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(gfxCtx, "../z_boss_ganon.c", 11074),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sLightningTextures[eff->timer]));
+            IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, eff->timer);
             gSPDisplayList(POLY_XLU_DISP++, gGanondorfLightningDL);
         }
     }

--- a/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
+++ b/src/overlays/actors/ovl_Boss_Va/z_boss_va.c
@@ -3495,6 +3495,7 @@ void BossVa_DrawEffects(BossVaEffect* effect, PlayState* play) {
     u8 materialFlag = 0;
     BossVaEffect* effectHead = effect;
     Camera* subCam = Play_GetCamera(play, sSubCamId);
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_boss_va.c", 4953);
 
@@ -3535,6 +3536,7 @@ void BossVa_DrawEffects(BossVaEffect* effect, PlayState* play) {
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gDPPipeSync(POLY_XLU_DISP++);
             gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sSparkBallTex[effect->mode]));
+            IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, effect->mode);
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, effect->primColor[0], effect->primColor[1], effect->primColor[2],
                             effect->primColor[3]);
             gDPPipeSync(POLY_XLU_DISP++);

--- a/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
+++ b/src/overlays/actors/ovl_En_Bdfire/z_en_bdfire.c
@@ -193,6 +193,7 @@ void EnBdfire_DrawFire(EnBdfire* this, PlayState* play) {
     };
     s16 texIndex;
     s32 pad;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_bdfire.c", 612);
     texIndex = this->unk_156 & 7;
@@ -206,6 +207,7 @@ void EnBdfire_DrawFire(EnBdfire* this, PlayState* play) {
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 100, (s8)this->unk_18C);
     gDPSetEnvColor(POLY_XLU_DISP++, 200, 0, 0, 0);
     gSPSegment(POLY_XLU_DISP++, 8, SEGMENTED_TO_VIRTUAL(D_809BCB10[texIndex]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, texIndex);
     Matrix_Translate(0.0f, 11.0f, 0.0f, MTXMODE_APPLY);
     gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_bdfire.c", 647),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
+++ b/src/overlays/actors/ovl_En_Ex_Ruppy/z_en_ex_ruppy.c
@@ -379,13 +379,7 @@ void EnExRuppy_Draw(Actor* thisx, PlayState* play) {
     static void* rupeeTextures[] = {
         gRupeeGreenTex, gRupeeBlueTex, gRupeeRedTex, gRupeePinkTex, gRupeeOrangeTex,
     };
-#if ENABLE_F3DEX3
-    // It might seem that we'd need to ensure this is reset every frame. But we
-    // actually only care about when this changes within a frame, as the texture
-    // loads would only ever be skipped between two or more rupees drawn
-    // consecutively.
-    static s16 lastColorIdx = -1;
-#endif
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
     s32 pad;
     EnExRuppy* this = (EnExRuppy*)thisx;
 
@@ -397,17 +391,7 @@ void EnExRuppy_Draw(Actor* thisx, PlayState* play) {
         gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_ex_ruppy.c", 780),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(rupeeTextures[this->colorIdx]));
-#if ENABLE_F3DEX3
-        // If we have consecutive rupees rendering with different textures,
-        // F3DEX3's optimizer will incorrectly believe the texture loads can be
-        // skipped, so this command tells it not to skip them. However, if the
-        // rupee really is the same as last time, then we can let the optimizer
-        // skip the load.
-        if (this->colorIdx != lastColorIdx) {
-            gSPDontSkipTexLoadsAcross(POLY_OPA_DISP++);
-            lastColorIdx = this->colorIdx;
-        }
-#endif
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, this->colorIdx);
         gSPDisplayList(POLY_OPA_DISP++, gRupeeDL);
 
         CLOSE_DISPS(play->state.gfxCtx, "../z_en_ex_ruppy.c", 784);

--- a/src/overlays/actors/ovl_En_Fd/z_en_fd.c
+++ b/src/overlays/actors/ovl_En_Fd/z_en_fd.c
@@ -880,6 +880,7 @@ void EnFd_DrawEffectsFlames(EnFd* this, PlayState* play) {
     s16 pad;
     s16 materialFlag;
     EnFdEffect* eff = this->effects;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_fd.c", 1969);
 
@@ -907,6 +908,7 @@ void EnFd_DrawEffectsFlames(EnFd* this, PlayState* play) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         idx = eff->timer * (8.0f / eff->initialTimer);
         gSPSegment(POLY_XLU_DISP++, 0x8, SEGMENTED_TO_VIRTUAL(dustTextures[idx]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, idx);
         gSPDisplayList(POLY_XLU_DISP++, gFlareDancerSquareParticleDL);
     }
 

--- a/src/overlays/actors/ovl_En_Fw/z_en_fw.c
+++ b/src/overlays/actors/ovl_En_Fw/z_en_fw.c
@@ -456,6 +456,7 @@ void EnFw_DrawEffects(EnFw* this, PlayState* play) {
     s16 alpha;
     s16 i;
     s16 idx;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_fw.c", 1191);
 
@@ -484,6 +485,7 @@ void EnFw_DrawEffects(EnFw* this, PlayState* play) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         idx = eff->timer * (8.0f / eff->initialTimer);
         gSPSegment(POLY_XLU_DISP++, 0x8, SEGMENTED_TO_VIRTUAL(dustTextures[idx]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, idx);
         gSPDisplayList(POLY_XLU_DISP++, gFlareDancerSquareParticleDL);
     }
 

--- a/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
+++ b/src/overlays/actors/ovl_En_G_Switch/z_en_g_switch.c
@@ -477,6 +477,7 @@ static void* sRupeeTextures[] = {
 void EnGSwitch_DrawRupee(Actor* thisx, PlayState* play) {
     s32 pad;
     EnGSwitch* this = (EnGSwitch*)thisx;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     if (1) {}
     if (!this->broken) {
@@ -486,6 +487,7 @@ void EnGSwitch_DrawRupee(Actor* thisx, PlayState* play) {
         gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_g_switch.c", 957),
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sRupeeTextures[this->colorIdx]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, this->colorIdx);
         gSPDisplayList(POLY_OPA_DISP++, gRupeeDL);
         CLOSE_DISPS(play->state.gfxCtx, "../z_en_g_switch.c", 961);
     }
@@ -556,6 +558,7 @@ void EnGSwitch_DrawEffects(EnGSwitch* this, PlayState* play) {
     s16 i;
     f32 scale;
     s32 pad;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_en_g_switch.c", 1073);
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
@@ -570,6 +573,7 @@ void EnGSwitch_DrawEffects(EnGSwitch* this, PlayState* play) {
             gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_en_g_switch.c", 1088),
                       G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sRupeeTextures[effect->colorIdx]));
+            IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, effect->colorIdx);
             gSPDisplayList(POLY_OPA_DISP++, gRupeeDL);
         }
     }

--- a/src/overlays/actors/ovl_En_Gb/z_en_gb.c
+++ b/src/overlays/actors/ovl_En_Gb/z_en_gb.c
@@ -518,6 +518,7 @@ void EnGb_UpdateCagedSouls(EnGb* this, PlayState* play) {
 void EnGb_DrawCagedSouls(EnGb* this, PlayState* play) {
     s32 pad;
     s32 i;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_gb.c", 914);
 
@@ -530,6 +531,7 @@ void EnGb_DrawCagedSouls(EnGb* this, PlayState* play) {
                    Gfx_TwoTexScroll(play->state.gfxCtx, G_TX_RENDERTILE, 0, 0, 32, 64, 1, 0,
                                     (u32)(sCagedSoulInfo[idx].timerMultiplier * this->frameTimer) % 512, 32, 128));
         gSPSegment(POLY_XLU_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(sCagedSoulInfo[idx].texture));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, idx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, sCagedSoulInfo[idx].prim.r, sCagedSoulInfo[idx].prim.g,
                         sCagedSoulInfo[idx].prim.b, sCagedSoulInfo[idx].prim.a);
         gDPSetEnvColor(POLY_XLU_DISP++, sCagedSoulInfo[idx].env.r, sCagedSoulInfo[idx].env.g, sCagedSoulInfo[idx].env.b,

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -1194,6 +1194,7 @@ void EnGo_DrawEffects(EnGo* this, PlayState* play) {
     s16 materialFlag;
     s16 index;
     s16 i;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go.c", 2626);
     materialFlag = false;
@@ -1222,6 +1223,7 @@ void EnGo_DrawEffects(EnGo* this, PlayState* play) {
 
         index = dustEffect->timer * (8.0f / dustEffect->initialTimer);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(dustTex[index]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, index);
         gSPDisplayList(POLY_XLU_DISP++, gGoronDL_00FD50);
     }
 

--- a/src/overlays/actors/ovl_En_Go2/z_en_go2.c
+++ b/src/overlays/actors/ovl_En_Go2/z_en_go2.c
@@ -218,6 +218,7 @@ void EnGo2_DrawEffects(EnGo2* this, PlayState* play) {
     s16 materialFlag;
     s16 index;
     s16 i;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_go2_eff.c", 111);
 
@@ -246,6 +247,7 @@ void EnGo2_DrawEffects(EnGo2* this, PlayState* play) {
                   G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         index = dustEffect->timer * (8.0f / dustEffect->initialTimer);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sDustTex[index]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, index);
         gSPDisplayList(POLY_XLU_DISP++, gGoronDL_00FD50);
     }
 

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -86,6 +86,7 @@ void EnTkEff_Draw(EnTk* this, PlayState* play) {
     s16 gfxSetup;
     s16 alpha;
     s16 i;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_en_tk_eff.c", 114);
 
@@ -117,6 +118,7 @@ void EnTkEff_Draw(EnTk* this, PlayState* play) {
 
         imageIdx = eff->timeLeft * ((f32)ARRAY_COUNT(dustTextures) / eff->timeTotal);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(dustTextures[imageIdx]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, imageIdx);
 
         gSPDisplayList(POLY_XLU_DISP++, gDampeEff2DL);
     }

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -635,6 +635,7 @@ void ObjOshihiki_Update(Actor* thisx, PlayState* play) {
 void ObjOshihiki_Draw(Actor* thisx, PlayState* play) {
     s32 pad;
     ObjOshihiki* this = (ObjOshihiki*)thisx;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_obj_oshihiki.c", 1289);
     if (ObjOshihiki_MoveWithBlockUnder(this, play)) {
@@ -643,6 +644,7 @@ void ObjOshihiki_Draw(Actor* thisx, PlayState* play) {
     this->stateFlags &= ~PUSHBLOCK_MOVE_UNDER;
     Gfx_SetupDL_25Opa(play->state.gfxCtx);
     gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(this->texture));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, this->texture);
 
     gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_obj_oshihiki.c", 1308),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -769,6 +769,7 @@ void ObjSwitch_DrawEye(ObjSwitch* this, PlayState* play) {
     };
     s32 pad;
     s32 subType = OBJSWITCH_SUBTYPE(&this->dyna.actor);
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_obj_switch.c", 1459);
 
@@ -776,6 +777,7 @@ void ObjSwitch_DrawEye(ObjSwitch* this, PlayState* play) {
     gSPMatrix(POLY_OPA_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_obj_switch.c", 1462),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPSegment(POLY_OPA_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(eyeTextures[subType][this->eyeTexIndex]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, 4 * subType + this->eyeTexIndex);
     gSPDisplayList(POLY_OPA_DISP++, eyeSwitchDLs[subType]);
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_obj_switch.c", 1471);
@@ -799,6 +801,7 @@ void ObjSwitch_DrawCrystal(ObjSwitch* this, PlayState* play) {
     s32 pad1;
     s32 pad2;
     s32 subType;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     subType = OBJSWITCH_SUBTYPE(&this->dyna.actor);
     func_8002ED80(&this->dyna.actor, play, 0);
@@ -822,6 +825,7 @@ void ObjSwitch_DrawCrystal(ObjSwitch* this, PlayState* play) {
 
     if (subType == OBJSWITCH_SUBTYPE_TOGGLE) {
         gSPSegment(POLY_OPA_DISP++, 0x09, SEGMENTED_TO_VIRTUAL(this->crystalSubtype1texture));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, this->crystalSubtype1texture);
     }
 
     gDPSetEnvColor(POLY_OPA_DISP++, this->crystalColor.r, this->crystalColor.g, this->crystalColor.b, 128);

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -752,6 +752,7 @@ void ObjectKankyo_Lightning(ObjectKankyo* this, PlayState* play) {
 void ObjectKankyo_DrawLightning(Actor* thisx, PlayState* play) {
     s32 pad;
     ObjectKankyo* this = (ObjectKankyo*)thisx;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_object_kankyo.c", 1182);
 
@@ -765,6 +766,7 @@ void ObjectKankyo_DrawLightning(Actor* thisx, PlayState* play) {
         gDPSetEnvColor(POLY_XLU_DISP++, 0, 255, 255, 128);
         gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_object_kankyo.c", 1213), G_MTX_LOAD);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sEffLightningTextures[this->effects[0].timer]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->effects[0].timer);
         Gfx_SetupDL_61Xlu(play->state.gfxCtx);
         gSPMatrix(POLY_XLU_DISP++, &D_01000000, G_MTX_MODELVIEW | G_MTX_NOPUSH | G_MTX_MUL);
         gDPPipeSync(POLY_XLU_DISP++);

--- a/src/overlays/effects/ovl_Effect_Ss_Bomb/z_eff_ss_bomb.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Bomb/z_eff_ss_bomb.c
@@ -54,6 +54,7 @@ void EffectSsBomb_Draw(PlayState* play, u32 index, EffectSs* this) {
     s32 pad;
     f32 scale;
     s16 intensity;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     if (1) {}
 
@@ -74,6 +75,7 @@ void EffectSsBomb_Draw(PlayState* play, u32 index, EffectSs* this) {
     if (mtx != NULL) {
         gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sExplosionTextures[this->rTexIndex]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTexIndex);
         gDPPipeSync(POLY_XLU_DISP++);
         Gfx_SetupDL_61Xlu(gfxCtx);
         intensity = this->life * ((f32)255 / EFFSSBOMB_LIFESPAN);

--- a/src/overlays/effects/ovl_Effect_Ss_Bomb2/z_eff_ss_bomb2.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Bomb2/z_eff_ss_bomb2.c
@@ -72,6 +72,7 @@ void EffectSsBomb2_DrawFade(PlayState* play, u32 index, EffectSs* this) {
     Mtx* mtx;
     s32 pad;
     f32 scale;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_bomb2.c", 298);
 
@@ -90,6 +91,7 @@ void EffectSsBomb2_DrawFade(PlayState* play, u32 index, EffectSs* this) {
                         this->rPrimColorA);
         gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB, 0);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(textures[this->rTexIndex]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTexIndex);
         gSPDisplayList(POLY_XLU_DISP++, this->gfx);
     }
 

--- a/src/overlays/effects/ovl_Effect_Ss_Bubble/z_eff_ss_bubble.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Bubble/z_eff_ss_bubble.c
@@ -40,6 +40,7 @@ u32 EffectSsBubble_Init(PlayState* play, u32 index, EffectSs* this, void* initPa
 void EffectSsBubble_Draw(PlayState* play, u32 index, EffectSs* this) {
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     f32 scale = this->rScale / 100.0f;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_bubble.c", 154);
 
@@ -51,6 +52,7 @@ void EffectSsBubble_Draw(PlayState* play, u32 index, EffectSs* this) {
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, 255, 255, 255, 255);
     gDPSetEnvColor(POLY_OPA_DISP++, 150, 150, 150, 0);
     gSPSegment(POLY_OPA_DISP++, 0x08, this->gfx);
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_OPA_DISP++, this->gfx);
     gSPDisplayList(POLY_OPA_DISP++, SEGMENTED_TO_VIRTUAL(gEffBubbleDL));
 
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_bubble.c", 179);

--- a/src/overlays/effects/ovl_Effect_Ss_D_Fire/z_eff_ss_d_fire.c
+++ b/src/overlays/effects/ovl_Effect_Ss_D_Fire/z_eff_ss_d_fire.c
@@ -73,6 +73,7 @@ void EffectSsDFire_Draw(PlayState* play, u32 index, EffectSs* this) {
     void* objectPtr;
     Mtx* mtx;
     f32 scale;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     objectPtr = play->objectCtx.slots[this->rObjectSlot].segment;
 
@@ -97,6 +98,7 @@ void EffectSsDFire_Draw(PlayState* play, u32 index, EffectSs* this) {
                             this->rPrimColorA);
             gSegments[6] = VIRTUAL_TO_PHYSICAL(objectPtr);
             gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sTextures[this->rTexIndex]));
+            IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTexIndex);
             gSPDisplayList(POLY_XLU_DISP++, this->gfx);
         }
     }

--- a/src/overlays/effects/ovl_Effect_Ss_Dead_Db/z_eff_ss_dead_db.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Dead_Db/z_eff_ss_dead_db.c
@@ -69,6 +69,7 @@ void EffectSsDeadDb_Draw(PlayState* play, u32 index, EffectSs* this) {
     MtxF mfResult;
     Mtx* mtx;
     f32 scale;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_dead_db.c", 201);
 
@@ -87,6 +88,7 @@ void EffectSsDeadDb_Draw(PlayState* play, u32 index, EffectSs* this) {
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, this->rPrimColorB,
                         this->rPrimColorA);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sTextures[this->rTextIdx]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTextIdx);
         gSPDisplayList(POLY_XLU_DISP++, this->gfx);
     }
 

--- a/src/overlays/effects/ovl_Effect_Ss_Dt_Bubble/z_eff_ss_dt_bubble.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Dt_Bubble/z_eff_ss_dt_bubble.c
@@ -75,6 +75,7 @@ u32 EffectSsDtBubble_Init(PlayState* play, u32 index, EffectSs* this, void* init
 void EffectSsDtBubble_Draw(PlayState* play, u32 index, EffectSs* this) {
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     f32 scale;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_dt_bubble.c", 201);
 
@@ -89,6 +90,7 @@ void EffectSsDtBubble_Draw(PlayState* play, u32 index, EffectSs* this) {
     gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB,
                    (this->rEnvColorA * this->life) / this->rLifespan);
     gSPSegment(POLY_XLU_DISP++, 0x08, this->gfx);
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->gfx);
     gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gEffBubbleDL));
 
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_dt_bubble.c", 236);

--- a/src/overlays/effects/ovl_Effect_Ss_Dust/z_eff_ss_dust.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Dust/z_eff_ss_dust.c
@@ -88,6 +88,7 @@ void EffectSsDust_Draw(PlayState* play, u32 index, EffectSs* this) {
     s32 pad;
     Mtx* mtx;
     f32 scale;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_dust.c", 321);
 
@@ -104,6 +105,7 @@ void EffectSsDust_Draw(PlayState* play, u32 index, EffectSs* this) {
         gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gDPPipeSync(POLY_XLU_DISP++);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(dustTextures[this->rTexIndex]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTexIndex);
         POLY_XLU_DISP = Gfx_SetupDL(POLY_XLU_DISP, SETUPDL_0);
         gDPPipeSync(POLY_XLU_DISP++);
 

--- a/src/overlays/effects/ovl_Effect_Ss_Extra/z_eff_ss_extra.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Extra/z_eff_ss_extra.c
@@ -60,6 +60,7 @@ void EffectSsExtra_Draw(PlayState* play, u32 index, EffectSs* this) {
     s32 pad;
     f32 scale = this->rScale / 100.0f;
     void* objectPtr = play->objectCtx.slots[this->rObjectSlot].segment;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(play->state.gfxCtx, "../z_eff_ss_extra.c", 168);
 
@@ -72,6 +73,7 @@ void EffectSsExtra_Draw(PlayState* play, u32 index, EffectSs* this) {
     gSPMatrix(POLY_XLU_DISP++, MATRIX_NEW(play->state.gfxCtx, "../z_eff_ss_extra.c", 186),
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sTextures[this->rScoreIdx]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rScoreIdx);
     gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(object_yabusame_point_DL_000DC0));
 
     CLOSE_DISPS(play->state.gfxCtx, "../z_eff_ss_extra.c", 194);

--- a/src/overlays/effects/ovl_Effect_Ss_G_Magma2/z_eff_ss_g_magma2.c
+++ b/src/overlays/effects/ovl_Effect_Ss_G_Magma2/z_eff_ss_g_magma2.c
@@ -99,7 +99,7 @@ void EffectSsGMagma2_Draw(PlayState* play, u32 index, EffectSs* this) {
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, 0, this->rPrimColorA);
     gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, 0, this->rEnvColorA);
     gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sTextures[this->rTexIndex]));
-    IF_F3DEX3_DONT_SKIP_TEX_HERE(pkt, this->rTexIndex);
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTexIndex);
     gSPDisplayList(POLY_XLU_DISP++, this->gfx);
 
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_g_magma2.c", 311);

--- a/src/overlays/effects/ovl_Effect_Ss_G_Magma2/z_eff_ss_g_magma2.c
+++ b/src/overlays/effects/ovl_Effect_Ss_G_Magma2/z_eff_ss_g_magma2.c
@@ -76,6 +76,7 @@ void EffectSsGMagma2_Draw(PlayState* play, u32 index, EffectSs* this) {
     s32 pad;
     f32 scale;
     void* objectPtr;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     scale = this->rScale / 100.0f;
     objectPtr = play->objectCtx.slots[this->rObjectSlot].segment;
@@ -98,6 +99,7 @@ void EffectSsGMagma2_Draw(PlayState* play, u32 index, EffectSs* this) {
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, 0, this->rPrimColorA);
     gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, 0, this->rEnvColorA);
     gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sTextures[this->rTexIndex]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(pkt, this->rTexIndex);
     gSPDisplayList(POLY_XLU_DISP++, this->gfx);
 
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_g_magma2.c", 311);

--- a/src/overlays/effects/ovl_Effect_Ss_G_Spk/z_eff_ss_g_spk.c
+++ b/src/overlays/effects/ovl_Effect_Ss_G_Spk/z_eff_ss_g_spk.c
@@ -80,6 +80,7 @@ void EffectSsGSpk_Draw(PlayState* play, u32 index, EffectSs* this) {
     Mtx* mtx;
     f32 scale;
     s32 pad;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_g_spk.c", 208);
 
@@ -94,6 +95,7 @@ void EffectSsGSpk_Draw(PlayState* play, u32 index, EffectSs* this) {
     if (mtx != NULL) {
         gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sparkTextures[this->rTexIndex]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTexIndex);
         Gfx_SetupDL_60NoCDXlu(gfxCtx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, this->rPrimColorB, 255);
         gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB, this->rEnvColorA);

--- a/src/overlays/effects/ovl_Effect_Ss_HitMark/z_eff_ss_hitmark.c
+++ b/src/overlays/effects/ovl_Effect_Ss_HitMark/z_eff_ss_hitmark.c
@@ -78,6 +78,7 @@ void EffectSsHitMark_Draw(PlayState* play, u32 index, EffectSs* this) {
     Mtx* mtx;
     f32 scale;
     s32 pad;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_hitmark.c", 297);
 
@@ -93,6 +94,7 @@ void EffectSsHitMark_Draw(PlayState* play, u32 index, EffectSs* this) {
     if (mtx != NULL) {
         gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(sTextures[(this->rType * 8) + (this->rTexIndex)]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, (this->rType * 8) + (this->rTexIndex));
         Gfx_SetupDL_61Xlu(gfxCtx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, this->rPrimColorB, 255);
         gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB, 0);

--- a/src/overlays/effects/ovl_Effect_Ss_Lightning/z_eff_ss_lightning.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Lightning/z_eff_ss_lightning.c
@@ -82,6 +82,7 @@ void EffectSsLightning_Draw(PlayState* play, u32 index, EffectSs* this) {
     f32 yScale;
     s16 texIdx;
     f32 xzScale;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_lightning.c", 233);
 
@@ -108,6 +109,7 @@ void EffectSsLightning_Draw(PlayState* play, u32 index, EffectSs* this) {
         gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
         Gfx_SetupDL_61Xlu(gfxCtx);
         gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(lightningTextures[texIdx]));
+        IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, texIdx);
         gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, this->rPrimColorB,
                         this->rPrimColorA);
         gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB, this->rEnvColorA);

--- a/src/overlays/effects/ovl_Effect_Ss_Sibuki2/z_eff_ss_sibuki2.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Sibuki2/z_eff_ss_sibuki2.c
@@ -70,7 +70,7 @@ void EffectSsSibuki2_Draw(PlayState* play, u32 index, EffectSs* this) {
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, this->rPrimColorB, this->rPrimColorA);
     gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB, this->rEnvColorA);
     gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(bubbleTextures[this->rTexIndex]));
-    IF_F3DEX3_DONT_SKIP_TEX_HERE(pkt, this->rTexIndex);
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->rTexIndex);
     gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gEffUnusedBubblesDL));
 
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_sibuki2.c", 198);

--- a/src/overlays/effects/ovl_Effect_Ss_Sibuki2/z_eff_ss_sibuki2.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Sibuki2/z_eff_ss_sibuki2.c
@@ -58,6 +58,7 @@ void EffectSsSibuki2_Draw(PlayState* play, u32 index, EffectSs* this) {
     };
     GraphicsContext* gfxCtx = play->state.gfxCtx;
     f32 scale = this->rScale / 100.0f;
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_sibuki2.c", 158);
 
@@ -69,6 +70,7 @@ void EffectSsSibuki2_Draw(PlayState* play, u32 index, EffectSs* this) {
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, this->rPrimColorR, this->rPrimColorG, this->rPrimColorB, this->rPrimColorA);
     gDPSetEnvColor(POLY_XLU_DISP++, this->rEnvColorR, this->rEnvColorG, this->rEnvColorB, this->rEnvColorA);
     gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(bubbleTextures[this->rTexIndex]));
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(pkt, this->rTexIndex);
     gSPDisplayList(POLY_XLU_DISP++, SEGMENTED_TO_VIRTUAL(gEffUnusedBubblesDL));
 
     CLOSE_DISPS(gfxCtx, "../z_eff_ss_sibuki2.c", 198);

--- a/src/overlays/effects/ovl_Effect_Ss_Stone1/z_eff_ss_stone1.c
+++ b/src/overlays/effects/ovl_Effect_Ss_Stone1/z_eff_ss_stone1.c
@@ -55,13 +55,7 @@ void EffectSsStone1_Draw(PlayState* play, u32 index, EffectSs* this) {
     Vec3f mfVec;
     f32 mfW;
     f32 scale;
-#if ENABLE_F3DEX3
-    // It might seem that we'd need to ensure this is reset every frame. But we
-    // actually only care about when this changes within a frame, as the texture
-    // loads would only ever be skipped between two or more particles drawn
-    // consecutively.
-    static s16 lastTextureIndex = -1;
-#endif
+    IF_F3DEX3_DONT_SKIP_TEX_INIT();
 
     OPEN_DISPS(gfxCtx, "../z_eff_ss_stone1.c", 154);
 
@@ -74,17 +68,7 @@ void EffectSsStone1_Draw(PlayState* play, u32 index, EffectSs* this) {
               G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     Gfx_SetupDL_61Xlu(gfxCtx);
     gSPSegment(POLY_XLU_DISP++, 0x08, SEGMENTED_TO_VIRTUAL(drawParams->texture));
-#if ENABLE_F3DEX3
-    // If we have consecutive particles rendering with different textures,
-    // F3DEX3's optimizer will incorrectly believe the texture loads can be
-    // skipped, so this command tells it not to skip them. However, if the
-    // particle really is the same as last time, then we can let the optimizer
-    // skip the load.
-    if (this->life != lastTextureIndex) {
-        gSPDontSkipTexLoadsAcross(POLY_OPA_DISP++);
-        lastTextureIndex = this->life;
-    }
-#endif
+    IF_F3DEX3_DONT_SKIP_TEX_HERE(POLY_XLU_DISP++, this->life);
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, drawParams->primColor.r, drawParams->primColor.g, drawParams->primColor.b,
                     255);
     gDPSetEnvColor(POLY_XLU_DISP++, drawParams->envColor.r, drawParams->envColor.g, drawParams->envColor.b, 255);


### PR DESCRIPTION
As discussed in #128 , F3DEX3's texture load optimizer can break when a display list is run repeatedly but with changing a segment in between to point to different textures. This will only cause problems when:
- there can be multiple of the objects in the scene rendered sequentially. If there is only ever one of them at a time, the issue will never arise.
- the object only has one material. If there are multiple materials, for example a character actor with eyes which are set by segment, the optimization will not occur because TMEM doesn't still contain the same texture.
- the choice of texture is independent for each object. If the segmented texture is hardcoded (e.g. `gSomething`) or if it's set by a process which is the same for all instances (e.g. global timer), the textures will be the same and the optimization is a good thing.

This PR aims to fix all cases of this. Macros are created which check if a different texture is being used between instances and if so disable the optimization. If F3DEX3 is disabled, these macros become no-ops.

Every effect was manually checked for cases like this. All other actors were scanned with a regex. It's possible some example was missed due to incomplete decomp names.