### PR TITLE
A few debugging quality-of-life improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "search.useIgnoreFiles": false,
     "search.exclude": {
         "**/.git": true,
+        ".venv/**": true,
         "baseroms/**": true,
         "build/**": true,
         "expected/**": true,

--- a/include/macros.h
+++ b/include/macros.h
@@ -125,22 +125,22 @@
 #endif
 
 #if IS_DEBUG
-#define LOG(exp, value, format, file, line)         \
+#define LOG(exp, value, format, ...)                \
     do {                                            \
-        LogUtils_LogThreadId(file, line);           \
+        LogUtils_LogThreadId(__FILE__, __LINE__);   \
         osSyncPrintf(exp " = " format "\n", value); \
     } while (0)
 #else
-#define LOG(exp, value, format, file, line) (void)(value)
+#define LOG(exp, value, format, ...) (void)(value)
 #endif
 
-#define LOG_STRING(string, file, line) LOG(#string, string, "%s", file, line)
-#define LOG_ADDRESS(exp, value, file, line) LOG(exp, value, "%08x", file, line)
-#define LOG_TIME(exp, value, file, line) LOG(exp, value, "%lld", file, line)
-#define LOG_NUM(exp, value, file, line) LOG(exp, value, "%d", file, line)
-#define LOG_HEX(exp, value, file, line) LOG(exp, value, "%x", file, line)
-#define LOG_HEX32(exp, value, file, line) LOG(exp, value, "%08x", file, line)
-#define LOG_FLOAT(exp, value, file, line) LOG(exp, value, "%f", file, line)
+#define LOG_STRING(string, ...) LOG(#string, string, "%s", __VA_ARGS__)
+#define LOG_ADDRESS(exp, value, ...) LOG(exp, value, "%08x", __VA_ARGS__)
+#define LOG_TIME(exp, value, ...) LOG(exp, value, "%lld", __VA_ARGS__)
+#define LOG_NUM(exp, value, ...) LOG(exp, value, "%d", __VA_ARGS__)
+#define LOG_HEX(exp, value, ...) LOG(exp, value, "%x", __VA_ARGS__)
+#define LOG_HEX32(exp, value, ...) LOG(exp, value, "%08x", __VA_ARGS__)
+#define LOG_FLOAT(exp, value, ...) LOG(exp, value, "%f", __VA_ARGS__)
 
 #define SET_NEXT_GAMESTATE(curState, newInit, newStruct) \
     do {                                                 \
@@ -175,72 +175,72 @@ extern struct GraphicsContext* __gfxCtx;
 
 // __gfxCtx shouldn't be used directly.
 // Use the DISP macros defined above when writing to display buffers.
-#define OPEN_DISPS(gfxCtx, file, line) \
-    {                                  \
-        GraphicsContext* __gfxCtx;     \
-        Gfx* dispRefs[4];              \
-        __gfxCtx = gfxCtx;             \
-        (void)__gfxCtx;                \
-        Graph_OpenDisps(dispRefs, gfxCtx, file, line)
+#define OPEN_DISPS(gfxCtx, ...)         \
+    {                                   \
+        GraphicsContext* __gfxCtx;      \
+        Gfx* dispRefs[4];               \
+        __gfxCtx = gfxCtx;              \
+        (void)__gfxCtx;                 \
+        Graph_OpenDisps(dispRefs, gfxCtx, __FILE__, __LINE__)
 
-#define CLOSE_DISPS(gfxCtx, file, line)                 \
-        Graph_CloseDisps(dispRefs, gfxCtx, file, line); \
-    }                                                   \
+#define CLOSE_DISPS(gfxCtx, ...)                                \
+        Graph_CloseDisps(dispRefs, gfxCtx, __FILE__, __LINE__); \
+    }                                                           \
     (void)0
 
 #define GRAPH_ALLOC(gfxCtx, size) Graph_Alloc(gfxCtx, size)
-#define MATRIX_TO_MTX(gfxCtx, file, line) Matrix_ToMtx(gfxCtx, file, line)
-#define MATRIX_NEW(gfxCtx, file, line) Matrix_NewMtx(gfxCtx, file, line)
-#define MATRIX_CHECK_FLOATS(mtx, file, line) Matrix_CheckFloats(mtx, file, line)
-#define DMA_REQUEST_SYNC(ram, vrom, size, file, line) DmaMgr_RequestSyncDebug(ram, vrom, size, file, line)
-#define DMA_REQUEST_ASYNC(req, ram, vrom, size, unk5, queue, msg, file, line) DmaMgr_RequestAsyncDebug(req, ram, vrom, size, unk5, queue, msg, file, line)
-#define GAME_STATE_ALLOC(gameState, size, file, line) GameState_Alloc(gameState, size, file, line)
-#define DEBUG_ARENA_MALLOC(size, file, line) DebugArena_MallocDebug(size, file, line)
-#define DEBUG_ARENA_MALLOC_R(size, file, line) DebugArena_MallocRDebug(size, file, line)
-#define DEBUG_ARENA_FREE(size, file, line) DebugArena_FreeDebug(size, file, line)
-#define SYSTEM_ARENA_MALLOC(size, file, line) SystemArena_MallocDebug(size, file, line)
-#define SYSTEM_ARENA_MALLOC_R(size, file, line) SystemArena_MallocRDebug(size, file, line)
-#define SYSTEM_ARENA_FREE(size, file, line) SystemArena_FreeDebug(size, file, line)
-#define ZELDA_ARENA_MALLOC(size, file, line) ZeldaArena_MallocDebug(size, file, line)
-#define ZELDA_ARENA_MALLOC_R(size, file, line) ZeldaArena_MallocRDebug(size, file, line)
-#define ZELDA_ARENA_FREE(size, file, line) ZeldaArena_FreeDebug(size, file, line)
-#define LOG_UTILS_CHECK_NULL_POINTER(exp, ptr, file, line) LogUtils_CheckNullPointer(exp, ptr, file, line)
-#define LOG_UTILS_CHECK_VALID_POINTER(exp, ptr, file, line) LogUtils_CheckValidPointer(exp, ptr, file, line)
-#define HUNGUP_AND_CRASH(file, line) Fault_AddHungupAndCrash(file, line)
-#define GAME_ALLOC_MALLOC(alloc, size, file, line) GameAlloc_MallocDebug(alloc, size, file, line)
+#define MATRIX_TO_MTX(gfxCtx, ...) Matrix_ToMtx(gfxCtx, __FILE__, __LINE__)
+#define MATRIX_NEW(gfxCtx, ...) Matrix_NewMtx(gfxCtx, __FILE__, __LINE__)
+#define MATRIX_CHECK_FLOATS(mtx, ...) Matrix_CheckFloats(mtx, __FILE__, __LINE__)
+#define DMA_REQUEST_SYNC(ram, vrom, size, ...) DmaMgr_RequestSyncDebug(ram, vrom, size, __FILE__, __LINE__)
+#define DMA_REQUEST_ASYNC(req, ram, vrom, size, unk5, queue, msg, ...) DmaMgr_RequestAsyncDebug(req, ram, vrom, size, unk5, queue, msg, __FILE__, __LINE__)
+#define GAME_STATE_ALLOC(gameState, size, ...) GameState_Alloc(gameState, size, __FILE__, __LINE__)
+#define DEBUG_ARENA_MALLOC(size, ...) DebugArena_MallocDebug(size, __FILE__, __LINE__)
+#define DEBUG_ARENA_MALLOC_R(size, ...) DebugArena_MallocRDebug(size, __FILE__, __LINE__)
+#define DEBUG_ARENA_FREE(size, ...) DebugArena_FreeDebug(size, __FILE__, __LINE__)
+#define SYSTEM_ARENA_MALLOC(size, ...) SystemArena_MallocDebug(size, __FILE__, __LINE__)
+#define SYSTEM_ARENA_MALLOC_R(size, ...) SystemArena_MallocRDebug(size, __FILE__, __LINE__)
+#define SYSTEM_ARENA_FREE(size, ...) SystemArena_FreeDebug(size, __FILE__, __LINE__)
+#define ZELDA_ARENA_MALLOC(size, ...) ZeldaArena_MallocDebug(size, __FILE__, __LINE__)
+#define ZELDA_ARENA_MALLOC_R(size, ...) ZeldaArena_MallocRDebug(size, __FILE__, __LINE__)
+#define ZELDA_ARENA_FREE(size, ...) ZeldaArena_FreeDebug(size, __FILE__, __LINE__)
+#define LOG_UTILS_CHECK_NULL_POINTER(exp, ptr, ...) LogUtils_CheckNullPointer(exp, ptr, __FILE__, __LINE__)
+#define LOG_UTILS_CHECK_VALID_POINTER(exp, ptr, ...) LogUtils_CheckValidPointer(exp, ptr, __FILE__, __LINE__)
+#define HUNGUP_AND_CRASH(...) Fault_AddHungupAndCrash(__FILE__, __LINE__)
+#define GAME_ALLOC_MALLOC(alloc, size, ...) GameAlloc_MallocDebug(alloc, size, __FILE__, __LINE__)
 
 #else
 
-#define OPEN_DISPS(gfxCtx, file, line)      \
+#define OPEN_DISPS(gfxCtx, ...)      \
     {                                       \
         GraphicsContext* __gfxCtx = gfxCtx; \
         s32 __dispPad
 
-#define CLOSE_DISPS(gfxCtx, file, line) \
+#define CLOSE_DISPS(gfxCtx, ...) \
     (void)0;                            \
     }                                   \
     (void)0
 
 #define GRAPH_ALLOC(gfxCtx, size) ((void*)((gfxCtx)->polyOpa.d = (Gfx*)((u8*)(gfxCtx)->polyOpa.d - ALIGN16(size))))
-#define MATRIX_TO_MTX(gfxCtx, file, line) Matrix_ToMtx(gfxCtx)
-#define MATRIX_NEW(gfxCtx, file, line) Matrix_NewMtx(gfxCtx)
-#define MATRIX_CHECK_FLOATS(mtx, file, line) (mtx)
-#define DMA_REQUEST_SYNC(ram, vrom, size, file, line) DmaMgr_RequestSync(ram, vrom, size)
-#define DMA_REQUEST_ASYNC(req, ram, vrom, size, unk5, queue, msg, file, line) DmaMgr_RequestAsync(req, ram, vrom, size, unk5, queue, msg)
-#define GAME_STATE_ALLOC(gameState, size, file, line) THA_AllocTailAlign16(&(gameState)->tha, size)
-#define DEBUG_ARENA_MALLOC(size, file, line) DebugArena_Malloc(size)
-#define DEBUG_ARENA_MALLOC_R(size, file, line) DebugArena_MallocR(size)
-#define DEBUG_ARENA_FREE(size, file, line) DebugArena_Free(size)
-#define SYSTEM_ARENA_MALLOC(size, file, line) SystemArena_Malloc(size)
-#define SYSTEM_ARENA_MALLOC_R(size, file, line) SystemArena_MallocR(size)
-#define SYSTEM_ARENA_FREE(size, file, line) SystemArena_Free(size)
-#define ZELDA_ARENA_MALLOC(size, file, line) ZeldaArena_Malloc(size)
-#define ZELDA_ARENA_MALLOC_R(size, file, line) ZeldaArena_MallocR(size)
-#define ZELDA_ARENA_FREE(size, file, line) ZeldaArena_Free(size)
-#define LOG_UTILS_CHECK_NULL_POINTER(exp, ptr, file, line) (void)0
-#define LOG_UTILS_CHECK_VALID_POINTER(exp, ptr, file, line) (void)0
-#define HUNGUP_AND_CRASH(file, line) LogUtils_HungupThread(file, line)
-#define GAME_ALLOC_MALLOC(alloc, size, file, line) GameAlloc_Malloc(alloc, size)
+#define MATRIX_TO_MTX(gfxCtx, ...) Matrix_ToMtx(gfxCtx)
+#define MATRIX_NEW(gfxCtx, ...) Matrix_NewMtx(gfxCtx)
+#define MATRIX_CHECK_FLOATS(mtx, ...) (mtx)
+#define DMA_REQUEST_SYNC(ram, vrom, size, ...) DmaMgr_RequestSync(ram, vrom, size)
+#define DMA_REQUEST_ASYNC(req, ram, vrom, size, unk5, queue, msg, ...) DmaMgr_RequestAsync(req, ram, vrom, size, unk5, queue, msg)
+#define GAME_STATE_ALLOC(gameState, size, ...) THA_AllocTailAlign16(&(gameState)->tha, size)
+#define DEBUG_ARENA_MALLOC(size, ...) DebugArena_Malloc(size)
+#define DEBUG_ARENA_MALLOC_R(size, ...) DebugArena_MallocR(size)
+#define DEBUG_ARENA_FREE(size, ...) DebugArena_Free(size)
+#define SYSTEM_ARENA_MALLOC(size, ...) SystemArena_Malloc(size)
+#define SYSTEM_ARENA_MALLOC_R(size, ...) SystemArena_MallocR(size)
+#define SYSTEM_ARENA_FREE(size, ...) SystemArena_Free(size)
+#define ZELDA_ARENA_MALLOC(size, ...) ZeldaArena_Malloc(size)
+#define ZELDA_ARENA_MALLOC_R(size, ...) ZeldaArena_MallocR(size)
+#define ZELDA_ARENA_FREE(size, ...) ZeldaArena_Free(size)
+#define LOG_UTILS_CHECK_NULL_POINTER(exp, ptr, ...) (void)0
+#define LOG_UTILS_CHECK_VALID_POINTER(exp, ptr, ...) (void)0
+#define HUNGUP_AND_CRASH(...) LogUtils_HungupThread(...)
+#define GAME_ALLOC_MALLOC(alloc, size, ...) GameAlloc_Malloc(alloc, size)
 
 #endif /* IS_DEBUG */
 

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -160,10 +160,11 @@ void Graph_Destroy(GraphicsContext* gfxCtx) {
 #endif
 }
 
-void Graph_TaskSet00(GraphicsContext* gfxCtx) {
 #if IS_DEBUG
-    static Gfx* sPrevTaskWorkBuffer = NULL;
+Gfx* gPrevTaskWorkBuffer = NULL;
 #endif
+
+void Graph_TaskSet00(GraphicsContext* gfxCtx) {
     static s32 sGraphCfbInfoIdx = 0;
 
     OSTime timeNow;
@@ -191,11 +192,11 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
             LogUtils_LogHexDump(gGfxSPTaskYieldBuffer, sizeof(gGfxSPTaskYieldBuffer));
 
             SREG(6) = -1;
-            if (sPrevTaskWorkBuffer != NULL) {
+            if (gPrevTaskWorkBuffer != NULL) {
                 R_HREG_MODE = HREG_MODE_UCODE_DISAS;
                 R_UCODE_DISAS_TOGGLE = 1;
                 R_UCODE_DISAS_LOG_LEVEL = 2;
-                Graph_DisassembleUCode(sPrevTaskWorkBuffer);
+                Graph_DisassembleUCode(gPrevTaskWorkBuffer);
             }
 #endif
 
@@ -205,7 +206,7 @@ void Graph_TaskSet00(GraphicsContext* gfxCtx) {
         osRecvMesg(&gfxCtx->queue, &msg, OS_MESG_NOBLOCK);
 
 #if IS_DEBUG
-        sPrevTaskWorkBuffer = gfxCtx->workBuffer;
+        gPrevTaskWorkBuffer = gfxCtx->workBuffer;
 #endif
 
         if (gfxCtx->callback != NULL) {
@@ -497,36 +498,32 @@ void* Graph_Alloc2(GraphicsContext* gfxCtx, size_t size) {
 
 #if IS_DEBUG
 void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line) {
-    if (R_HREG_MODE == HREG_MODE_UCODE_DISAS && R_UCODE_DISAS_LOG_MODE != 4) {
-        dispRefs[0] = gfxCtx->polyOpa.p;
-        dispRefs[1] = gfxCtx->polyXlu.p;
-        dispRefs[2] = gfxCtx->overlay.p;
+    dispRefs[0] = gfxCtx->polyOpa.p;
+    dispRefs[1] = gfxCtx->polyXlu.p;
+    dispRefs[2] = gfxCtx->overlay.p;
 
-        gDPNoOpOpenDisp(gfxCtx->polyOpa.p++, file, line);
-        gDPNoOpOpenDisp(gfxCtx->polyXlu.p++, file, line);
-        gDPNoOpOpenDisp(gfxCtx->overlay.p++, file, line);
-    }
+    gDPNoOpOpenDisp(gfxCtx->polyOpa.p++, file, line);
+    gDPNoOpOpenDisp(gfxCtx->polyXlu.p++, file, line);
+    gDPNoOpOpenDisp(gfxCtx->overlay.p++, file, line);
 }
 
 void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line) {
-    if (R_HREG_MODE == HREG_MODE_UCODE_DISAS && R_UCODE_DISAS_LOG_MODE != 4) {
-        if (dispRefs[0] + 1 == gfxCtx->polyOpa.p) {
-            gfxCtx->polyOpa.p = dispRefs[0];
-        } else {
-            gDPNoOpCloseDisp(gfxCtx->polyOpa.p++, file, line);
-        }
+    if (dispRefs[0] + 1 == gfxCtx->polyOpa.p) {
+        gfxCtx->polyOpa.p = dispRefs[0];
+    } else {
+        gDPNoOpCloseDisp(gfxCtx->polyOpa.p++, file, line);
+    }
 
-        if (dispRefs[1] + 1 == gfxCtx->polyXlu.p) {
-            gfxCtx->polyXlu.p = dispRefs[1];
-        } else {
-            gDPNoOpCloseDisp(gfxCtx->polyXlu.p++, file, line);
-        }
+    if (dispRefs[1] + 1 == gfxCtx->polyXlu.p) {
+        gfxCtx->polyXlu.p = dispRefs[1];
+    } else {
+        gDPNoOpCloseDisp(gfxCtx->polyXlu.p++, file, line);
+    }
 
-        if (dispRefs[2] + 1 == gfxCtx->overlay.p) {
-            gfxCtx->overlay.p = dispRefs[2];
-        } else {
-            gDPNoOpCloseDisp(gfxCtx->overlay.p++, file, line);
-        }
+    if (dispRefs[2] + 1 == gfxCtx->overlay.p) {
+        gfxCtx->overlay.p = dispRefs[2];
+    } else {
+        gDPNoOpCloseDisp(gfxCtx->overlay.p++, file, line);
     }
 }
 #endif


### PR DESCRIPTION
This does three things that should improve the debugging experience. The first changes all file and line args for debug macros to use the real file and line rather than the matching file and line. (e.g. instead of `../graph.c` with an inaccurate line number it shows `src/code/graph.c` with an accurate line number) The latter two changes make gfx debugging much easier.
 * Change macros that take file name and line number args to report the true file name and line number.
 * Ensure that (in debug builds) open/close disps always inserts the no-op debug markers.
 * Move sPrevTaskWorkBuffer to global gPrevTaskWorkBuffer for easy access to the address in the map file.

After these changes a [gfx debugger](https://github.com/Thar0/gbd) (shameless advertisement) can report accurate traces of where in the source code gfx commands were appended to the graphics task:
![image](https://github.com/HackerN64/HackerOoT/assets/17233964/8d574c64-e674-447f-a0f6-ebb5cc7fcf1f)
