### PR TITLE
Promote some compiler warnings to errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ INC := -Iinclude -Iinclude/libc -Isrc -I$(BUILD_DIR) -I. -I$(EXTRACTED_DIR)
 
 # Check code syntax with host compiler
 CHECK_WARNINGS := -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces
+CHECK_WARNINGS += -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=int-conversion
 
 # The `cpp` command behaves differently on macOS (it behaves as if
 # `-traditional-cpp` was passed) so we use `gcc -E` instead.

--- a/include/compression.h
+++ b/include/compression.h
@@ -2,6 +2,7 @@
 #define COMPRESSION_H
 
 #include "ultra64.h"
+#include "z64dma.h"
 
 void* Yaz0_FirstDMA(void);
 void* Yaz0_NextDMA(u8* curSrcPos);

--- a/src/code/sys_math3d_draw.c
+++ b/src/code/sys_math3d_draw.c
@@ -1,4 +1,5 @@
 #include "z64.h"
+#include "functions.h"
 
 #if IS_DEBUG
 void Math3D_VtxF2L(Vtx* r, Vec3f* v) {


### PR DESCRIPTION
This PR promotes the following compiler warnings to errors, and fixes any occurrences of them:
- `implicit-function-declaration`
  This warning appears when calling a function whose prototype is not visible. In the worst case a missing prototype can lead to bad codegen and crashes. On newer gcc releases this has been promoted to an error by default, so this backports that change to older gcc versions for consistency between contributors. This change has also already been made upstream.
- `int-conversion`
  This warning appears when converting a pointer to an integer without an explicit cast, e.g. by passing a pointer to an integer arg in a function call. On newer gcc releases this has been promoted to an error by default, so this backports that change to older gcc versions for consistency between contributors.
- `incompatible-pointer-types`
  This warning appears whenever a pointer of one type is used as a pointer to another type. This is a surprisingly common error to run into during development and there's no circumstance where you'd ever want this to not stop compilation, it can save much debugging time.