### PR TITLE
Fix f3dex2 crash caused by using gDPNoOp disp macros when GBI_DEBUG was not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ else ifeq ($(VERSION),gc-eu-mq-dbg)
   CPP_DEFINES += -DOOT_MQ
   HACKEROOT := 0
 else ifeq ($(VERSION),hackeroot-mq)
+  DEBUG := 1
   CPP_DEFINES += -DOOT_MQ
   HACKEROOT := 1
 else

--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -498,6 +498,7 @@ void* Graph_Alloc2(GraphicsContext* gfxCtx, size_t size) {
 
 #if IS_DEBUG
 void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line) {
+#if GBI_DEBUG
     dispRefs[0] = gfxCtx->polyOpa.p;
     dispRefs[1] = gfxCtx->polyXlu.p;
     dispRefs[2] = gfxCtx->overlay.p;
@@ -505,9 +506,11 @@ void Graph_OpenDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, 
     gDPNoOpOpenDisp(gfxCtx->polyOpa.p++, file, line);
     gDPNoOpOpenDisp(gfxCtx->polyXlu.p++, file, line);
     gDPNoOpOpenDisp(gfxCtx->overlay.p++, file, line);
+#endif
 }
 
 void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file, int line) {
+#if GBI_DEBUG
     if (dispRefs[0] + 1 == gfxCtx->polyOpa.p) {
         gfxCtx->polyOpa.p = dispRefs[0];
     } else {
@@ -525,5 +528,6 @@ void Graph_CloseDisps(Gfx** dispRefs, GraphicsContext* gfxCtx, const char* file,
     } else {
         gDPNoOpCloseDisp(gfxCtx->overlay.p++, file, line);
     }
+#endif
 }
 #endif


### PR DESCRIPTION
Figured out with gbd :tm:
![image](https://github.com/user-attachments/assets/ab53f453-f0fa-4dd8-a94b-4d30c9ee2f29)
