### PR TITLE
Create workflow for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    container: ghcr.io/HackerN64/HackerBuild:main
+    container: ghcr.io/hackern64/hackerbuild:main
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,17 +11,19 @@ jobs:
     strategy:
       matrix:
         include:
-          - TARGET: "Debug, No F3DEX3"
-            MAKE_VARS: RELEASE=0 CPP_DEFINES=-DENABLE_F3DEX3=0
-          - TARGET: "Debug, F3DEX3"
-            MAKE_VARS: RELEASE=0 CPP_DEFINES=-DENABLE_F3DEX3=1
-          - TARGET: "Release, No F3DEX3"
-            MAKE_VARS: RELEASE=1 CPP_DEFINES=-DENABLE_F3DEX3=0
-          - TARGET: "Release, F3DEX3"
-            MAKE_VARS: RELEASE=1 CPP_DEFINES=-DENABLE_F3DEX3=1
+          - name: "Debug, No F3DEX3"
+            args: RELEASE=0 CPP_DEFINES=-DENABLE_F3DEX3=0
+          - name: "Debug, F3DEX3"
+            args: RELEASE=0 CPP_DEFINES=-DENABLE_F3DEX3=1
+          - name: "Release, No F3DEX3"
+            args: RELEASE=1 CPP_DEFINES=-DENABLE_F3DEX3=0
+          - name: "Release, F3DEX3"
+            args: RELEASE=1 CPP_DEFINES=-DENABLE_F3DEX3=1
     defaults:
       run:
         shell: bash
+    
+    name: ${{ matrix.name }}
 
     steps:
     # Checkout the repository (shallow clone)
@@ -50,5 +52,5 @@ jobs:
       run: make setup -j$(nproc)
 
     # Build the project
-    - name: Build (${{ matrix.TARGET }})
-      run: ${{ matrix.MAKE_VARS }} make -j$(nproc)
+    - name: Build
+      run: ${{ matrix.args }} make -j$(nproc)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    container: ghcr.io/yanis42/hackeroot-build-test:main
+    container: ghcr.io/HackerN64/HackerBuild:main
     runs-on: ubuntu-22.04
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    container: ghcr.io/yanis42/hackeroot-build-test:main
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - TARGET: "Debug, No F3DEX3"
+            MAKE_VARS: RELEASE=0 CPP_DEFINES=-DENABLE_F3DEX3=0
+          - TARGET: "Debug, F3DEX3"
+            MAKE_VARS: RELEASE=0 CPP_DEFINES=-DENABLE_F3DEX3=1
+          - TARGET: "Release, No F3DEX3"
+            MAKE_VARS: RELEASE=1 CPP_DEFINES=-DENABLE_F3DEX3=0
+          - TARGET: "Release, F3DEX3"
+            MAKE_VARS: RELEASE=1 CPP_DEFINES=-DENABLE_F3DEX3=1
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    # Checkout the repository (shallow clone)
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    # Set Git config
+    - name: Git config
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+    # Copy the original files to the workspace
+    - name: Prepare
+      run: cp -R /HackerOoT/baseroms .
+
+    # Install the required pip packages
+    - name: Setup Python
+      run: |
+        python3 -m pip install --user colorama ansiwrap attrs watchdog python-Levenshtein "mapfile-parser>=1.2.1,<2.0.0" "rabbitizer>=1.0.0,<2.0.0"
+        python3 -m pip install --upgrade attrs pycparser
+
+    # Setup the project
+    - name: Setup
+      run: make setup -j$(nproc)
+
+    # Build the project
+    - name: Build (${{ matrix.TARGET }})
+      run: ${{ matrix.MAKE_VARS }} make -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ARES_GDB := 1
 
 # Toggle release or debug mode. 1=Release, 0=Debug
 # Note: currently only used for HackerOoT
-RELEASE := 0
+RELEASE ?= 0
 
 # Valid compression algorithms are 'yaz', 'lzo' and 'aplib'
 COMPRESSION ?= yaz

--- a/include/config/config_graphics.h
+++ b/include/config/config_graphics.h
@@ -9,8 +9,11 @@
  * F3DEX3 options
  * This only works on real console or LLE emulators like ares or ParaLLEl. It
  * will not work on legacy HLE emulators such as Project64.
+ * Note: you can define this with `CPP_DEFINES=-DENABLE_F3DEX3=0 make -j$(nproc)`
 */
+#ifndef ENABLE_F3DEX3
 #define ENABLE_F3DEX3 true
+#endif
 // Remove usually-unnecessary syncs from texture loading commands. Only matters
 // for vanilla display lists--new ones exported from fast64 already have the
 // syncs removed. This is buggy (graphical issues / crashes) as some vanilla DLs


### PR DESCRIPTION
This adds a workflow to add building this project to CI, this do NOT upload any build artifacts.

It will build the repo 4 times:
- debug mode, no F3DEX3
- debug mode, with F3DEX3
- release mode, no F3DEX3
- release mode, with F3DEX3

why? we get a lot of feedback from people not being able to build it and everytime I test myself it always works (even from fresh clones), basically the purpose is telling us when we have real build issues, it won't make sure the thing actually boots (obviously)

hopefully works first try (it did on my test branch the other day), this CI build idea was taken from [dtk-template](https://github.com/encounter/dtk-template)