### PR TITLE
Added make rules for the SC64

### DIFF
--- a/.make_hackeroot.mk
+++ b/.make_hackeroot.mk
@@ -43,3 +43,20 @@ else ifeq ($(TARGET),iso)
 CFLAGS := -DCONSOLE_GC -fno-reorder-blocks -fno-optimize-sibling-calls
 CPPFLAGS := -DCONSOLE_GC
 endif
+
+### SummerCart64 Settings ###
+
+# path to the deployer program
+SC64_DEPLOYER ?=
+
+# upload the build
+sc64: rom
+ifeq ($(SC64_DEPLOYER),)
+	$(error sc64deployer path not set. Set SC64_DEPLOYER in the Makefile or define it as an environment variable)
+endif
+	$(SC64_DEPLOYER) upload $(ROM)
+	$(SC64_DEPLOYER) debug --isv 0x03FF0000
+
+# same as above and start listening to the IS-Viewer
+sc64v: sc64
+	$(SC64_DEPLOYER) debug --isv 0x03FF0000

--- a/.make_hackeroot.mk
+++ b/.make_hackeroot.mk
@@ -55,7 +55,6 @@ ifeq ($(SC64_DEPLOYER),)
 	$(error sc64deployer path not set. Set SC64_DEPLOYER in the Makefile or define it as an environment variable)
 endif
 	$(SC64_DEPLOYER) upload $(ROM)
-	$(SC64_DEPLOYER) debug --isv 0x03FF0000
 
 # same as above and start listening to the IS-Viewer
 sc64v: sc64


### PR DESCRIPTION
This adds a variable called `SC64_DEPLOYER` that can be set to the path of the sc64deployer, it adds also two rules:
- `sc64`: build and upload
- `sc64v`: same as above and start the is-viewer thing

more summercart features soon™