### PR TITLE
Fix Z-target reticle in widescreen

### DIFF
--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -428,6 +428,10 @@ void Attention_Draw(Attention* attention, PlayState* play) {
 
         Actor_ProjectPos(play, &attention->reticlePos, &projectedPos, &invW);
 
+        if (USE_WIDESCREEN) {
+            projectedPos.x /= (0.75f);
+        }
+
         projectedPos.x = ((SCREEN_WIDTH / 2) * (projectedPos.x * invW)) * projectdPosScale;
         projectedPos.x = CLAMP(projectedPos.x, -SCREEN_WIDTH, SCREEN_WIDTH);
 


### PR DESCRIPTION
Fixes the z-targetting reticle being offset in widescreen